### PR TITLE
Add gs_batch profile: cloud GPU basecalling on Google Cloud Batch

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,76 @@ and aligning it with `minimap2` to produce a sorted, indexed CRAM.
 
 
 
+## AbstractBio — Cloud GPU basecalling on Google Cloud Batch (`gs_batch` profile)
+
+This fork adds a single Nextflow profile, **`gs_batch`**, that offloads the GPU
+basecalling step to **Google Cloud Batch** (NVIDIA A100 by default, L4 as a fallback)
+while the lightweight Nextflow head runs locally (e.g. in WSL). It is a fallback for
+when local `dorado` basecalling is unavailable. The whole change lives in `base.config`
+(the `gs_batch` profile block) plus one line in `nextflow.config`; ONT's own per-process
+containers are reused, so there is **no custom GPU image to build**.
+
+### Prerequisites (run once)
+
+The local Nextflow head needs Java 17, the `nf-google` plugin (auto-loaded by the
+profile), and a GCP service-account key with Batch + GCS permissions. Export these in the
+shell that launches the run:
+
+```
+export JAVA_HOME=/path/to/java-17
+export GOOGLE_APPLICATION_CREDENTIALS=/path/to/sa-key.json   # SA with batch.jobsEditor + GCS access
+```
+
+### Test command (smoke test)
+
+Point `--input` at a small local directory of `.pod5` files and send FASTQ to a GCS bucket:
+
+```
+nextflow run AbstractBio/wf-basecalling -r gs-batch-profile -profile gs_batch \
+    --input        /path/to/pod5_dir \
+    --dorado_ext   pod5 \
+    --basecaller_cfg dna_r10.4.1_e8.2_400bps_sup@v5.2.0 \
+    --output_fmt   fastq \
+    --out_dir      gs://processed-sequencing/<run_id>/fastq_pass/ \
+    --gpu_machine  a2-highgpu-1g \
+    --gcp_location us-west1
+```
+
+A successful run writes `SAMPLE.pass.fq.gz` / `SAMPLE.fail.fq.gz` + a report directly into
+the `gs://` `--out_dir`.
+
+### What each part represents
+
+| Flag | What it does |
+| --- | --- |
+| `-r gs-batch-profile` | Pin the fork branch that contains the `gs_batch` profile (omit when running a local clone). |
+| `-profile gs_batch` | Use Google Cloud Batch as the executor; GPU only on the `dorado`/`bonito` step, CPU steps on cheap VMs. |
+| `--input` | **Local** directory of signal files; searched recursively for `**.<dorado_ext>`. |
+| `--dorado_ext` | `pod5` (default) or `fast5` — which signal files to ingest. |
+| `--basecaller_cfg` | The dorado model. `sup` = highest accuracy (production); `hac`/`fast` are quicker. |
+| `--output_fmt fastq` | Emit FASTQ. Default is `cram`; **FASTQ is only valid when no `--ref` is given.** |
+| `--out_dir` | Output location. Accepts a `gs://` path directly (published by the workflow, no local staging). |
+| `--gpu_machine` | GPU VM. `a2-highgpu-1g` = 1× A100 (default); `g2-standard-16` = 1× L4 (fallback). The accelerator type is derived automatically from this. |
+| `--gcp_location` | GCP region for Batch. Must have GPU quota (A100/L4 confirmed in `us-west1`). |
+
+Other profile params (CLI-overridable): `--gcp_project` (default `short-term-storage`),
+`--gcp_spot true` (preemptible GPUs — cheaper, risks mid-basecall preemption; off by default),
+`--gcp_workdir` (gs:// Batch work dir).
+
+### Tuning notes
+
++ **`--basecaller_chunk_size`** (default `25`) = the max number of pod5 files grouped into
+  one chunk, and **one GPU task runs per chunk**. *Raise* it to spin up **fewer** GPU VMs
+  (less parallelism, more work per VM); *lower* it for more, smaller parallel GPU tasks.
++ Each Nextflow task is its own Batch VM, so a tiny input spends most of its wall-clock on
+  VM provisioning + container pulls. On real data the parallel `dorado` GPU tasks dominate
+  and that fixed overhead amortizes away.
++ Real-time / streaming mode: add `--watch_path` to basecall pod5s as they land in the
+  local input dir (stop with `--read_limit` or a `STOP.<sessionId>.pod5` sentinel file).
+
+
+
+
 ## Compute requirements
 
 Recommended requirements:

--- a/base.config
+++ b/base.config
@@ -97,6 +97,60 @@ profiles {
     discrete_gpus {
         process."withLabel:gpu".maxForks = null
     }
+
+    // Google Cloud Batch: offload the GPU basecaller to a cloud GPU VM.
+    // Mirrors the awsbatch profile, but for Nextflow's google-batch executor.
+    // The stock public ontresearch/dorado container (set by withLabel:wf_basecalling
+    // in the default `process {}` block above) works as-is — Cloud Batch installs the
+    // NVIDIA driver into the VM via google.batch.installGpuDrivers, so we do NOT need
+    // the aws_image_prefix `-dorado-cloud` image variant the awsbatch profile uses.
+    //
+    // GPU selection is a single param: --gpu_machine. A100 'a2-highgpu-1g' (default)
+    // and L4 'g2-standard-16' are accelerator-optimised machine types. The basecaller
+    // processes hardcode `accelerator 1` (lib/signal/ingress.nf) with no type, which
+    // Cloud Batch rejects ("count:1 should have type and count configured"). So we
+    // OVERRIDE accelerator here with an explicit [type, count], deriving the GPU type
+    // from the machine family (g2-* => nvidia-l4, else nvidia-tesla-a100).
+    // Override infra defaults on the CLI, e.g.:
+    //   nextflow run AbstractBio/wf-basecalling -profile gs_batch \
+    //     --gpu_machine g2-standard-16 --gcp_location us-central1
+    gs_batch {
+        params {
+            gpu_machine  = 'a2-highgpu-1g'                          // A100; L4: 'g2-standard-16'
+            gcp_project  = 'short-term-storage'
+            gcp_location = 'us-west1'                               // A100 region may differ; override if needed
+            gcp_spot     = false                                   // on-demand by default (no mid-basecall preemption)
+            gcp_workdir  = 'gs://scratch-nextflow/wf-basecalling/work'
+        }
+        process {
+            executor = 'google-batch'
+            shell = ['/bin/bash', '-euo', 'pipefail']
+            // Batch gcsfuse-mounts the gs:// workDir without `allow_other`, so any container
+            // running as a NON-root user gets EACCES on .command.run (exit 126). The dorado
+            // image (used by gpu AND the non-gpu wf_basecalling steps: qsFilter, summaries,
+            // merge, split) is non-root, while wf-common is root. Force ALL containers to
+            // root (uid 0 == the gcsfuse mount owner) as a profile-wide default; the gpu
+            // label re-states it alongside the NVIDIA env (withLabel replaces, not merges).
+            containerOptions = "--user 0:0"
+            // lift the serial-GPU limit (as discrete_gpus does) and pin the GPU VM.
+            withLabel:gpu {
+                maxForks = null
+                machineType = params.gpu_machine
+                accelerator = [type: (params.gpu_machine.startsWith('g2') ? 'nvidia-l4' : 'nvidia-tesla-a100'), request: 1, limit: 1]
+                // NVIDIA env for the GPU; --user 0:0 re-stated (see profile-wide note above —
+                // withLabel replaces process.containerOptions rather than merging).
+                containerOptions = "-e NVIDIA_DRIVER_CAPABILITIES=compute,utility --user 0:0"
+            }
+        }
+        google {
+            project  = params.gcp_project
+            location = params.gcp_location
+            batch.installGpuDrivers = true
+            batch.spot = params.gcp_spot
+        }
+        // google-batch requires a gs:// work directory.
+        workDir = params.gcp_workdir
+    }
 }
 
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -13,7 +13,7 @@ params {
     monochrome_logs = false
     validate_params = true
     show_hidden_params = false
-    schema_ignore_params = 'show_hidden_params,validate_params,monochrome_logs,aws_queue,aws_image_prefix,wf'
+    schema_ignore_params = 'show_hidden_params,validate_params,monochrome_logs,aws_queue,aws_image_prefix,wf,gpu_machine,gcp_project,gcp_location,gcp_spot,gcp_workdir'
 
     // I/O
     input = null


### PR DESCRIPTION
Offload the dorado GPU step to Google Cloud Batch via a new `gs_batch` Nextflow profile (google-batch executor), as a fallback for when local basecalling is unavailable. The Nextflow head runs locally; GPU only on the basecaller (A100 a2-highgpu-1g default, L4 g2-standard-16 fallback), CPU steps on cheap VMs. Reuses ONT's per-process containers (no custom image).

Changes (base.config gs_batch block + nextflow.config):
- executor=google-batch, withLabel:gpu pinned to --gpu_machine; accelerator type derived from the machine family as [type, request, limit] -- not `count`, which the executor null-casts; installGpuDrivers; gs:// workDir.
- --user 0:0 on all containers: Batch gcsfuse-mounts the gs:// workDir without allow_other, so the non-root dorado image gets EACCES (exit 126) on .command.run.
- Register the profile's params in nextflow.config schema_ignore_params (nf-schema strict validation; a profile-level override does not win over the top-level value).

Validated end-to-end: pod5 -> A100 Batch dorado sup@v5.2.0 -> FASTQ in a gs:// out_dir.

README: AbstractBio section with the test command + per-flag explanation.